### PR TITLE
Fix errors in build workflows

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion = 'success'
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
@@ -51,6 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion = 'failure'
+      github.event.workflow_run.conclusion == 'failure'
     steps:
       - run: echo 'The trigger workflow failed.'

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion = 'success'
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
@@ -51,6 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion = 'failure'
+      github.event.workflow_run.conclusion == 'failure'
     steps:
       - run: echo 'The trigger workflow failed.'

--- a/.github/workflows/rc-deploy.yml
+++ b/.github/workflows/rc-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion = 'success'
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
@@ -51,6 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion = 'failure'
+      github.event.workflow_run.conclusion == 'failure'
     steps:
       - run: echo 'The trigger workflow failed.'


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5670

### Description (What does it do?)

There's a typo in the workflows to build the CI, RC, and prod versions of the code - this fixes that.

### How can this be tested?

Mostly review it. Some of these won't run until things get merged into `release-candidate` or `release`. But the CI one should probably work.