### PR TITLE
Fixes some more minor things in the build actions

### DIFF
--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -26,10 +26,10 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_UE_API_BASE_URL: "http://ue.test.local:9080"
+          NEXT_PUBLIC_UE_API_BASE_URL: "https://api.pay-ci.ol.mit.edu/"
 
       - name: Write commit SHA to file
-        run: echo $GITHUB_SHA > frontends/main/public/hash.txt
+        run: echo $GITHUB_SHA > out/hash.txt
 
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/ci-deploy.yml
+++ b/.github/workflows/ci-deploy.yml
@@ -26,8 +26,7 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_UE_API_BASE_URL: "https://api.pay-ci.ol.mit.edu/"
-
+          NEXT_PUBLIC_UE_API_BASE_URL: ${{ vars.API_BASE_CI}}
       - name: Write commit SHA to file
         run: echo $GITHUB_SHA > out/hash.txt
 

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -26,10 +26,10 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_UE_API_BASE_URL: "http://ue.test.local:9080"
+          NEXT_PUBLIC_UE_API_BASE_URL: "https://api.pay.ol.mit.edu/"
 
       - name: Write commit SHA to file
-        run: echo $GITHUB_SHA > frontends/main/public/hash.txt
+        run: echo $GITHUB_SHA > out/hash.txt
 
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_UE_API_BASE_URL: "https://api.pay.ol.mit.edu/"
+          NEXT_PUBLIC_UE_API_BASE_URL: ${{ vars.API_BASE_PROD }}
 
       - name: Write commit SHA to file
         run: echo $GITHUB_SHA > out/hash.txt

--- a/.github/workflows/rc-deploy.yml
+++ b/.github/workflows/rc-deploy.yml
@@ -26,10 +26,10 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_UE_API_BASE_URL: "http://ue.test.local:9080"
+          NEXT_PUBLIC_UE_API_BASE_URL: "https://api.pay-rc.ol.mit.edu/"
 
       - name: Write commit SHA to file
-        run: echo $GITHUB_SHA > frontends/main/public/hash.txt
+        run: echo $GITHUB_SHA > out/hash.txt
 
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/rc-deploy.yml
+++ b/.github/workflows/rc-deploy.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_UE_API_BASE_URL: "https://api.pay-rc.ol.mit.edu/"
+          NEXT_PUBLIC_UE_API_BASE_URL: ${{ vars.API_BASE_RC }}
 
       - name: Write commit SHA to file
         run: echo $GITHUB_SHA > out/hash.txt


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/6201
https://github.com/mitodl/hq/issues/5670

### Description (What does it do?)

- Make the API base URLs configurable using variables
- Fix the path for the commit SHA file - needed to be in `out/` not the other thing it was at

### How can this be tested?

Read through it - this changes the GitHub action workflows.

### Additional Context

The URLs are set in the repository variables. At least at time of writing, we're actively working on deploying the Django app so it seemed a good idea to be able to change these pretty easily. We can make these hard-coded again later.