### PR TITLE
Make dependency warnings (for useEffect, etc.) an error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,6 +68,7 @@ module.exports = {
           "Do not specify `fontFamily` manually. Prefer spreading `theme.typography.subtitle1` or similar. If using neue-haas-grotesk-text, this is ThemeProvider's default fontFamily.",
       },
     ],
+    "react-hooks/exhaustive-deps": ["error"],
   },
   overrides: [
     {


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

While reviewing a PR, I noticed that a warning for the dependency list in a `useEffect` call was being flagged but that it sill passed tests. So, this updates the eslint config to regard these warnings as errors.

### How can this be tested?

This is just an eslint rule change - you could adjust the dependencies on a `useEffect` call in the codebase so it triggers the error when you run `yarn lint-check`.